### PR TITLE
Fixed issue with passing inverted bits keyword arguments

### DIFF
--- a/adafruit_il0373.py
+++ b/adafruit_il0373.py
@@ -69,7 +69,25 @@ _STOP_SEQUENCE = (
 )
 # pylint: disable=too-few-public-methods
 class IL0373(displayio.EPaperDisplay):
-    """IL0373 driver"""
+    r"""IL0373 driver
+
+    :param bus: The data bus the display is on
+    :param bool swap_rams: Color and black rams/commands are swapped
+    :param \**kwargs:
+        See below
+
+    :Keyword Arguments:
+        * *width* (``int``) --
+          Display width
+        * *height* (``int``) --
+          Display height
+        * *rotation* (``int``) --
+          Display rotation
+        * *color_bits_inverted* (``bool``) --
+          Invert color bit values
+        * *black_bits_inverted* (``bool``) --
+          Invert black bit values
+    """
     def __init__(self, bus, swap_rams=False, **kwargs):
         start_sequence = bytearray(_START_SEQUENCE)
 

--- a/adafruit_il0373.py
+++ b/adafruit_il0373.py
@@ -83,9 +83,9 @@ class IL0373(displayio.EPaperDisplay):
         start_sequence[27] = (height >> 8) & 0xFF
         start_sequence[28] = height & 0xFF
         if swap_rams:
-            color_bits_inverted = kwargs.pop("black_bits_inverted", False)
+            color_bits_inverted = kwargs.pop("color_bits_inverted", False)
             write_color_ram_command = 0x10
-            black_bits_inverted = kwargs.pop("color_bits_inverted", True)
+            black_bits_inverted = kwargs.pop("black_bits_inverted", True)
             write_black_ram_command = 0x13
         else:
             write_black_ram_command = 0x10

--- a/adafruit_il0373.py
+++ b/adafruit_il0373.py
@@ -83,15 +83,15 @@ class IL0373(displayio.EPaperDisplay):
         start_sequence[27] = (height >> 8) & 0xFF
         start_sequence[28] = height & 0xFF
         if swap_rams:
-            color_bits_inverted = kwargs.get("black_bits_inverted", False)
+            color_bits_inverted = kwargs.pop("black_bits_inverted", False)
             write_color_ram_command = 0x10
-            black_bits_inverted = kwargs.get("color_bits_inverted", True)
+            black_bits_inverted = kwargs.pop("color_bits_inverted", True)
             write_black_ram_command = 0x13
         else:
             write_black_ram_command = 0x10
             write_color_ram_command = 0x13
-            color_bits_inverted = kwargs.get("color_bits_inverted", True)
-            black_bits_inverted = kwargs.get("black_bits_inverted", False)
+            color_bits_inverted = kwargs.pop("color_bits_inverted", True)
+            black_bits_inverted = kwargs.pop("black_bits_inverted", False)
         super().__init__(bus, start_sequence, _STOP_SEQUENCE, **kwargs,
                          ram_width=160, ram_height=296,
                          busy_state=False,


### PR DESCRIPTION
When a user passes in black_bits_inverted or color_bits_inverted the IL0373 initializer will pass  the keyword argument twice to the displayio.EPaperDisplay initializer rwhich raises an exception ('TypeError: extra keyword arguments given').

The fix is to swap dict.get for dict.pop