### PR TITLE
Update the pixel_shader usage of OnDiskBitmap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,6 @@ This is easily achieved by downloading
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
-
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-il0373/>`_. To install for current user:
 
@@ -86,7 +83,12 @@ Usage Example
     f = open("/display-ruler.bmp", "rb")
 
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,30 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/il0373_simpletest.py
     :caption: examples/il0373_simpletest.py
     :linenos:
+
+Device Specific Examples
+------------------------
+
+.. literalinclude:: ../examples/il0373_1.54_color.py
+    :caption: examples/il0373_1.54_color.py
+    :linenos:
+
+.. literalinclude:: ../examples/il0373_2.9_color.py
+    :caption: examples/il0373_2.9_color.py
+    :linenos:
+
+.. literalinclude:: ../examples/il0373_2.9_grayscale.py
+    :caption: examples/il0373_2.9_grayscale.py
+    :linenos:
+
+.. literalinclude:: ../examples/il0373_2.13_color.py
+    :caption: examples/il0373_2.13_color.py
+    :linenos:
+
+.. literalinclude:: ../examples/il0373_flexible_2.9_monochrome.py
+    :caption: examples/il0373_flexible_2.9_monochrome.py
+    :linenos:
+
+.. literalinclude:: ../examples/il0373_flexible_2.13_monochrome.py
+    :caption: examples/il0373_2.13_monochrome.py
+    :linenos:

--- a/examples/il0373_1.54_color.py
+++ b/examples/il0373_1.54_color.py
@@ -40,7 +40,12 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/il0373_2.13_color.py
+++ b/examples/il0373_2.13_color.py
@@ -47,7 +47,12 @@ g = displayio.Group()
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
     # Create a Tilegrid with the bitmap and put in the displayio group
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     # Place the display group on the screen

--- a/examples/il0373_2.9_color.py
+++ b/examples/il0373_2.9_color.py
@@ -46,7 +46,12 @@ g = displayio.Group()
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
     # Create a Tilegrid with the bitmap and put in the displayio group
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     # Place the display group on the screen

--- a/examples/il0373_2.9_grayscale.py
+++ b/examples/il0373_2.9_grayscale.py
@@ -41,7 +41,12 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/il0373_flexible_2.13_monochrome.py
+++ b/examples/il0373_flexible_2.13_monochrome.py
@@ -35,7 +35,12 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/il0373_flexible_2.9_monochrome.py
+++ b/examples/il0373_flexible_2.9_monochrome.py
@@ -35,7 +35,12 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/il0373_simpletest.py
+++ b/examples/il0373_simpletest.py
@@ -31,7 +31,12 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)


### PR DESCRIPTION
OnDiskBitmap has had incompatible changes in `7.0.0-alpha.3` - Ref: https://github.com/adafruit/circuitpython/pull/4823
This PR is part of a group of updates for this change - https://github.com/adafruit/circuitpython/issues/4982

Also, an out-of-date note in `README.rst` has been removed.

This PR updates the library to the combined usage for CP6 & CP7.
It has not been tested as I do not have the hardware.