### PR TITLE
Update for CircuitPython 9 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Usage Example
     import time
     import board
     import displayio
+    import fourwire
     import adafruit_il0373
 
     displayio.release_displays()
@@ -76,7 +77,7 @@ Usage Example
     epd_cs = board.D9
     epd_dc = board.D10
 
-    display_bus = displayio.FourWire(board.SPI(), command=epd_dc, chip_select=epd_cs, baudrate=1000000)
+    display_bus = fourwire.FourWire(board.SPI(), command=epd_dc, chip_select=epd_cs, baudrate=1000000)
     time.sleep(1)
 
     display = adafruit_il0373.IL0373(display_bus, width=212, height=104, rotation=90,
@@ -95,7 +96,7 @@ Usage Example
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/il0373_1.54_color.py
+++ b/examples/il0373_1.54_color.py
@@ -11,6 +11,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 displayio.release_displays()
@@ -22,7 +23,7 @@ epd_dc = board.D10
 epd_reset = board.D5
 epd_busy = board.D6
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)
@@ -48,7 +49,7 @@ with open("/display-ruler.bmp", "rb") as f:
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/il0373_2.13_color.py
+++ b/examples/il0373_2.13_color.py
@@ -11,6 +11,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 # Used to ensure the display is free in CircuitPython
@@ -25,7 +26,7 @@ epd_reset = board.D5
 epd_busy = board.D6
 
 # Create the displayio connection to the display pins
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)  # Wait a bit
@@ -56,7 +57,7 @@ with open("/display-ruler.bmp", "rb") as f:
     g.append(t)
 
     # Place the display group on the screen
-    display.show(g)
+    display.root_group = g
 
     # Refresh the display to have it actually show the image
     # NOTE: Do not refresh eInk displays sooner than 180 seconds

--- a/examples/il0373_2.9_color.py
+++ b/examples/il0373_2.9_color.py
@@ -10,6 +10,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 # Used to ensure the display is free in CircuitPython
@@ -24,7 +25,7 @@ epd_reset = board.D5
 epd_busy = board.D6
 
 # Create the displayio connection to the display pins
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)  # Wait a bit
@@ -55,7 +56,7 @@ with open("/display-ruler.bmp", "rb") as f:
     g.append(t)
 
     # Place the display group on the screen
-    display.show(g)
+    display.root_group = g
 
     # Refresh the display to have it actually show the image
     # NOTE: Do not refresh eInk displays sooner than 180 seconds

--- a/examples/il0373_2.9_grayscale.py
+++ b/examples/il0373_2.9_grayscale.py
@@ -12,6 +12,7 @@ import time
 import busio
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 displayio.release_displays()
@@ -21,7 +22,7 @@ spi = busio.SPI(board.SCK, board.MOSI)  # Uses SCK and MOSI
 epd_cs = board.D9
 epd_dc = board.D10
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, baudrate=1000000
 )
 time.sleep(1)
@@ -49,7 +50,7 @@ with open("/display-ruler.bmp", "rb") as f:
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/il0373_flexible_2.13_monochrome.py
+++ b/examples/il0373_flexible_2.13_monochrome.py
@@ -11,6 +11,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 displayio.release_displays()
@@ -22,7 +23,7 @@ epd_dc = board.D10
 epd_reset = board.D5
 epd_busy = board.D6
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)
@@ -43,7 +44,7 @@ with open("/display-ruler.bmp", "rb") as f:
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/il0373_flexible_2.9_monochrome.py
+++ b/examples/il0373_flexible_2.9_monochrome.py
@@ -11,6 +11,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 displayio.release_displays()
@@ -22,7 +23,7 @@ epd_dc = board.D10
 epd_reset = board.D5
 epd_busy = board.D6
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)
@@ -43,7 +44,7 @@ with open("/display-ruler.bmp", "rb") as f:
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/il0373_simpletest.py
+++ b/examples/il0373_simpletest.py
@@ -11,6 +11,7 @@ Supported products:
 import time
 import board
 import displayio
+import fourwire
 import adafruit_il0373
 
 displayio.release_displays()
@@ -18,7 +19,7 @@ displayio.release_displays()
 epd_cs = board.D9
 epd_dc = board.D10
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     board.SPI(), command=epd_dc, chip_select=epd_cs, baudrate=1000000
 )
 time.sleep(1)
@@ -39,7 +40,7 @@ with open("/display-ruler.bmp", "rb") as f:
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 


### PR DESCRIPTION
Replaces instances of `displayio.FourWire` with `fourwire.FourWire` and update to use `root_group` in README and examples